### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/utility.cpp
+++ b/utility.cpp
@@ -47,7 +47,7 @@ public:
     }
 
 private:
-    int fixedSeed = 42; //fixed seed for sensitivity analysis
+    std::mt19937::result_type fixedSeed = 42; //fixed seed for sensitivity analysis
     static RandomNumberGenerator *s_instance;
     //RandomNumberGenerator() : m_engine{rd()}, m_distribution{0.f, 1.f} {}
     RandomNumberGenerator() : m_engine{fixedSeed}, m_distribution{0.f, 1.f} {}
@@ -60,7 +60,7 @@ private:
 
 RandomNumberGenerator *RandomNumberGenerator::s_instance;
 
-void _assert(bool condition, const char *message)
+void verboseAssert(bool condition, const char *message)
 {
     if (!condition) {
         std::cerr << message << std::endl;

--- a/utility.h
+++ b/utility.h
@@ -2,7 +2,7 @@
 #define WILDLAND_FIRESIM_UTILITY_H
 
 #ifndef _NDEBUG
-#define WILDLAND_ASSERT(c, m) wildland_firesim::utility::_assert((c), (m))
+#define WILDLAND_ASSERT(c, m) wildland_firesim::utility::verboseAssert((c), (m))
 #else
 #define WILDLAND_ASSERT(c, m)
 #endif
@@ -13,7 +13,7 @@
 namespace wildland_firesim {
 namespace utility {
 
-void _assert(bool condition, const char *message);
+void verboseAssert(bool condition, const char *message);
 
 /*!
  * \brief random


### PR DESCRIPTION
On FreeBSD, the libc implementation also has an `_assert` macro. This
collides with the `_assert` function in the `wildland_firesim:utility`
namespace. Renaming it to `verboseAssert` resolves this issue while also
being a bit more specific on the functions intention.

Also, the `clang++` 7.0 on FreeBSD complains about the seed argument of
the random number generator being narrowed down, so instead of using a
generic `int` the type is now dependent on the `result_type` of the
random number generator.